### PR TITLE
Add support for ending inline HTML/SGML comment annotations when comment itself ends

### DIFF
--- a/lib/linter-annotations-provider.js
+++ b/lib/linter-annotations-provider.js
@@ -82,6 +82,7 @@ export default {
     return this.trim(str)
       .replace(/\s*\*\/$/g, '')
       .replace(/\s*%>$/g, '')
+      .replace(/\s*-->.*$/g, '')
   },
 
   trim (str) {

--- a/spec/linter-annotations-provider-spec.js
+++ b/spec/linter-annotations-provider-spec.js
@@ -26,6 +26,7 @@ describe('Provider', () => {
     it('Should strip comment endings', () => {
       expect(Provider.trimCommentEnd('/* test */')).toEqual('/* test')
       expect(Provider.trimCommentEnd('<%# test %>')).toEqual('<%# test')
+      expect(Provider.trimCommentEnd('<!-- test --> remove')).toEqual('<!-- test')
     })
   })
 


### PR DESCRIPTION
Hi there!

Thanks for your great plugin. I'm using it as part of a project I'm working on, and it's helping quite a bit. One thing I noticed is that, for my use case, which involves seeing TODO (and other custom) tags inside of inline HTML comments, the annotation itself would continue until the end of the line, and not end at the end of the HTML comment itself.

Thankfully, this was an easy fix, and I figured I would send along this pull request so you can go ahead and integrate this into the next version you put out.

As an example of the difference between the two:

Before:
<img width="598" alt="screenshot 2017-09-16 20 34 59" src="https://user-images.githubusercontent.com/280610/30517024-87021578-9b1e-11e7-9045-856e971380d6.png">

After:
<img width="605" alt="screenshot 2017-09-16 20 28 15" src="https://user-images.githubusercontent.com/280610/30517017-542d1ba2-9b1e-11e7-8751-9b95dba2ec6c.png">

It was a simple, one-line change, and I hope you'll accept the pull request. I hope you and your family are in good health!

Ruth