### PR TITLE
trimCommentEnd now properly works inline for all comment styles

### DIFF
--- a/lib/linter-annotations-provider.js
+++ b/lib/linter-annotations-provider.js
@@ -83,10 +83,10 @@ export default {
   trimCommentEnd (str) {
     return str
       .replace(/\s*$/g, '')
-      .replace(/\*\/$/g, '')
-      .replace(/%>$/g, '')
+      .replace(/\*\/.*$/g, '')
+      .replace(/%>.*$/g, '')
+      .replace(/-->.*$/g, '')
       .replace(/\s*$/g, '')
-      .replace(/\s*-->.*$/g, '')
   },
 
   trim (str) {

--- a/spec/linter-annotations-provider-spec.js
+++ b/spec/linter-annotations-provider-spec.js
@@ -28,8 +28,8 @@ describe('Provider', () => {
 
   describe('trimCommentEnd()', () => {
     it('Should strip comment endings', () => {
-      expect(Provider.trimCommentEnd('/* test */')).toEqual('/* test')
-      expect(Provider.trimCommentEnd('<%# test %>')).toEqual('<%# test')
+      expect(Provider.trimCommentEnd('/* test */ remove')).toEqual('/* test')
+      expect(Provider.trimCommentEnd('<%# test %> remove')).toEqual('<%# test')
       expect(Provider.trimCommentEnd('<!-- test --> remove')).toEqual('<!-- test')
     })
   })


### PR DESCRIPTION
Hello,

Some time ago I submitted a pull request to allow trimming of HTML/SGML comments. Since then I have also needed to use other comment types that you already supported, but they would not trim properly if the comment was inlined in other text. This change does several things:

1. Reordered code and removed unnecessary code I placed in my last pull request caused by two misunderstandings in how the function operated in the first place
2. Adjusts all supported comment types so that any text in between the comment ending and the end of the line is also removed from the annotation
3. Adds tests to ensure that text after a comment ending is properly removed by trimCommentEnd (though I could not figure out how to run these tests; perhaps some info in the README about how to run the tests would be useful!)

Thank you!
Ruth